### PR TITLE
Add markdown rendering for bot responses

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -23,13 +23,12 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "frontend:build"
+            "buildTarget": "frontend:build"
           }
         }
       }
     }
   },
-  "defaultProject": "frontend",
   "cli": {
     "analytics": false
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,8 +16,9 @@
         "@angular/platform-browser": "^21.2.10",
         "@angular/platform-browser-dynamic": "^21.2.10",
         "@angular/router": "^21.2.10",
+        "marked": "^18.0.2",
         "rxjs": "^7.8.0",
-        "zone.js": "~0.14.0"
+        "zone.js": "~0.16.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^21.2.8",
@@ -7596,6 +7597,18 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11524,9 +11537,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
-      "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
+      "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
       "license": "MIT"
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0 --port 4200",
-    "build": "ng build --configuration production"
+    "build": "ng build"
   },
   "dependencies": {
     "@angular/animations": "^21.2.10",
@@ -16,8 +16,9 @@
     "@angular/platform-browser": "^21.2.10",
     "@angular/platform-browser-dynamic": "^21.2.10",
     "@angular/router": "^21.2.10",
+    "marked": "^18.0.2",
     "rxjs": "^7.8.0",
-    "zone.js": "~0.14.0"
+    "zone.js": "~0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.2.8",

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -201,7 +201,10 @@
   border-radius: 18px;
   position: relative;
   line-height: 1.5;
-  white-space: pre-wrap;
+}
+
+.message-content {
+  overflow-wrap: anywhere;
 }
 
 .message-bubble.user {
@@ -216,6 +219,51 @@
   background: #eef4ff;
   color: #172b4d;
   border-bottom-left-radius: 6px;
+}
+
+.message-bubble.user .message-content {
+  white-space: pre-wrap;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content > *:first-child {
+  margin-top: 0;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content > *:last-child {
+  margin-bottom: 0;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content p,
+:host ::ng-deep .message-bubble.bot .message-content ul,
+:host ::ng-deep .message-bubble.bot .message-content ol,
+:host ::ng-deep .message-bubble.bot .message-content pre,
+:host ::ng-deep .message-bubble.bot .message-content blockquote {
+  margin: 0 0 0.75rem;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content ul,
+:host ::ng-deep .message-bubble.bot .message-content ol {
+  padding-left: 1.25rem;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.92em;
+  background: rgba(29, 78, 216, 0.08);
+  padding: 0.15rem 0.35rem;
+  border-radius: 6px;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content pre {
+  background: rgba(23, 43, 77, 0.08);
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+:host ::ng-deep .message-bubble.bot .message-content pre code {
+  background: transparent;
+  padding: 0;
 }
 
 .message-time {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -59,7 +59,7 @@
           <ng-container *ngIf="selectedChat && selectedChat.messages.length; else emptyChat">
             <div class="message-row" *ngFor="let message of selectedChat.messages">
               <div [class.user]="message.role === 'user'" [class.bot]="message.role === 'bot'" class="message-bubble">
-                <div class="message-content">{{ message.content }}</div>
+                <div class="message-content" [innerHTML]="message.renderedContent || message.content"></div>
                 <div class="message-time">{{ message.timestamp }}</div>
               </div>
             </div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,9 +1,11 @@
 import { Component, ViewChild, ElementRef } from '@angular/core';
 import { ChatService } from './chat.service';
+import { marked } from 'marked';
 
 interface ChatMessage {
   role: 'user' | 'bot';
   content: string;
+  renderedContent?: string;
   timestamp: string;
 }
 
@@ -18,6 +20,7 @@ interface ChatSession {
 
 @Component({
   selector: 'app-root',
+  standalone: false,
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
@@ -32,6 +35,11 @@ export class AppComponent {
   @ViewChild('chatWindow', { static: false }) chatWindow!: ElementRef;
 
   constructor(private chatService: ChatService) {
+    marked.setOptions({
+      gfm: true,
+      breaks: true,
+    });
+
     // Automatisch ersten Chat erstellen
     this.createNewChat();
   }
@@ -144,6 +152,7 @@ export class AppComponent {
     currentChat.messages.push({
       role: 'user',
       content: userContent,
+      renderedContent: this.escapeHtml(userContent),
       timestamp: this.timeStamp(),
     });
 
@@ -191,10 +200,12 @@ export class AppComponent {
     });
   }
 
+  
   private handleApiResponse(response: string, chat: ChatSession): void {
     chat.messages.push({
       role: 'bot',
       content: response,
+      renderedContent: this.renderMarkdown(response),
       timestamp: this.timeStamp(),
     });
     this.scrollToBottom();
@@ -205,9 +216,24 @@ export class AppComponent {
     chat.messages.push({
       role: 'bot',
       content: `❌ ${errorMessage}`,
+      renderedContent: this.escapeHtml(`❌ ${errorMessage}`),
       timestamp: this.timeStamp(),
     });
     this.scrollToBottom();
+  }
+
+  private renderMarkdown(content: string): string {
+    return marked.parse(content) as string;
+  }
+
+  private escapeHtml(content: string): string {
+    return content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/\n/g, '<br />');
   }
 
   private scrollToBottom(): void {


### PR DESCRIPTION
Bot-Antwort wird jetzt im Frontend mit der Library marked von Markdown in HTML umgewandelt. Anschließend wird nicht mehr nur roher Text angezeigt, sondern die gerenderte HTML-Version in der Chat-Nachricht ausgegeben. Dadurch werden Markdown-Elemente wie Fettschrift, Aufzählungen, Inline-Code und Codeblöcke korrekt dargestellt.
Zusätzlich wurde das Styling für diese Inhalte ergänzt, damit Absätze, Listen und Codeblöcke im Chat sauber formatiert aussehen.  (User-Nachrichten bleiben normales Textformat, damit nur die KI-Antworten als Markdown interpretiert werden.)